### PR TITLE
feat: retry failed requests

### DIFF
--- a/pkg/crawler/crawler.go
+++ b/pkg/crawler/crawler.go
@@ -233,10 +233,12 @@ func (a *App) Crawl() {
 			a.clearCache(r.Request)
 			log.WithFields(
 				log.Fields{
-					"attempt": attempt,
-					"url":     r.Request.URL,
+					"attempt":     attempt,
+					"error":       err,
+					"status_code": r.StatusCode,
+					"url":         r.Request.URL,
 				},
-			).Warnf("delay for %d seconds before next request", delay)
+			).Warnf("delay for %v before next request", delay)
 			r.Ctx.Put("attempt", attempt+1)
 			time.Sleep(delay)
 			r.Request.Retry()
@@ -270,10 +272,12 @@ func (a *App) Crawl() {
 			a.clearCache(r.Request)
 			log.WithFields(
 				log.Fields{
-					"attempt": attempt,
-					"url":     r.Request.URL,
+					"attempt":     attempt,
+					"error":       err,
+					"status_code": r.StatusCode,
+					"url":         r.Request.URL,
 				},
-			).Warnf("delay for %d seconds before next request", delay)
+			).Warnf("delay for %v before next request", delay)
 			r.Ctx.Put("attempt", attempt+1)
 			time.Sleep(delay)
 			r.Request.Retry()

--- a/pkg/crawler/crawler.go
+++ b/pkg/crawler/crawler.go
@@ -238,7 +238,7 @@ func (a *App) Crawl() {
 					"status_code": r.StatusCode,
 					"url":         r.Request.URL,
 				},
-			).Warnf("delay for %v before next request", delay)
+			).Warnf("retrying request in %v", delay)
 			r.Ctx.Put("attempt", attempt+1)
 			time.Sleep(delay)
 			r.Request.Retry()
@@ -277,7 +277,7 @@ func (a *App) Crawl() {
 					"status_code": r.StatusCode,
 					"url":         r.Request.URL,
 				},
-			).Warnf("delay for %v before next request", delay)
+			).Warnf("retrying request in %v", delay)
 			r.Ctx.Put("attempt", attempt+1)
 			time.Sleep(delay)
 			r.Request.Retry()


### PR DESCRIPTION
- Go Colly does cache responses that are not 200 OK, including those with error status codes. Specifically, it caches every response with a status code lower than 500
- The cache removal logic is implemented based on https://github.com/gocolly/colly/blob/99b7fb1b87d1491578f1fa9c222836341f533d75/http_backend.go#L135-L138

Example:

```sh
INFO[0143] visited                                       status_code=200 url="https://guide.michelin.com/en/restaurants/the-plate-michelin/page/512"
WARN[0143] delay for 5s seconds before next request      attempt=1 url="https://guide.michelin.com/en/salzburg-region/salzburg/restaurant/brunnauer"
WARN[0150] delay for 5s seconds before next request      attempt=2 url="https://guide.michelin.com/en/salzburg-region/salzburg/restaurant/brunnauer"
WARN[0155] delay for 5s seconds before next request      attempt=3 url="https://guide.michelin.com/en/salzburg-region/salzburg/restaurant/brunnauer"
ERRO[0160] error                                         error="Moved Permanently" headers="&map[Accept:[*/*] Cookie:[JSESSIONID=abc] Referer:[https://guide.michelin.com/en/salzburg-region/salzburg/restaurant/brunnauer] User-Agent:[Opera/9.80 (Windows NT 6.1; Win64; x64; U; en) Presto/2.2.15 Version/10.00]]" status_code=301 url="https://guide.michelin.com/en/salzburg-region/salzburg/restaurant/brunnauer"
INFO[0160] visited                                       status_code=200 url="https://guide.michelin.com/en/restaurants/the-plate-michelin/page/513"
```