### PR TITLE
Fix xpath for address, description, price and cuisine

### DIFF
--- a/pkg/crawler/xpath.go
+++ b/pkg/crawler/xpath.go
@@ -12,14 +12,14 @@ const (
 	// E.g.: https://guide.michelin.com/en/singapore-region/singapore/restaurant/les-amis
 	restaurantDetailXPath = "//main[@class]"
 
-	restaurantAddressXPath               = "//*[@class='data-sheet__block--text'][1]"
-	restaurantDescriptionXPath           = "//*[@class='data-sheet__description']"
+	restaurantAddressXPath               = "//*[contains(@class, 'data-sheet__block--text')][1]"
+	restaurantDescriptionXPath           = "//*[contains(@class, 'data-sheet__description')]"
 	restaurantDistinctionXPath           = "//*[@class='data-sheet__classification-item--content'][2]"
 	restaurantFacilitiesAndServicesXPath = "//*[contains(@class, 'col col-12 col-lg-6')]//li"
 	restaurantGoogleMapsXPath            = "//*[@class='google-map__static']/iframe"
 	restaurantGreenStarXPath             = "//*[contains(text(),'MICHELIN Green Star')]"
 	restaurantNameXPath                  = "//*[@class='data-sheet__title']"
 	restaurantPhoneNumberXPath           = "//a[@data-event='CTA_tel']"
-	restaurantPriceAndCuisineXPath       = "//*[@class='data-sheet__block--text'][2]"
+	restaurantPriceAndCuisineXPath       = "//*[contains(@class, 'data-sheet__block--text')][2]"
 	restaurantWebsiteUrlXPath            = "//a[@data-event='CTA_website']"
 )


### PR DESCRIPTION
- Previous xpath could not find the elements if blanks are included in DOM class.
- Fixed this by using `contains()`.